### PR TITLE
Fixed Reset password delete bug

### DIFF
--- a/packages/auth/src/dal/resetDAL.ts
+++ b/packages/auth/src/dal/resetDAL.ts
@@ -48,9 +48,8 @@ export async function findResetPasswordRequestByCode(db: DbClient, code: string,
   return result.at(0);
 }
 
-export async function deleteResetPasswordRequest(db: DbClient, code: string): Promise<void> {
+export async function deleteResetPasswordRequest(db: DbClient, id: string): Promise<void> {
   await db
     .delete(resetPasswordRequest)
-    .where(eq(resetPasswordRequest.code, code))
-    .execute();
+    .where(eq(resetPasswordRequest.id, id));
 }

--- a/packages/base/src/graphql/identity.ts
+++ b/packages/base/src/graphql/identity.ts
@@ -54,6 +54,7 @@ builder.objectType('Invitation', {
     id: t.exposeID('id'),
     firstName: t.exposeString('firstName'),
     lastName: t.exposeString('lastName'),
+    email: t.exposeString('email'),
   }),
 });
 
@@ -114,7 +115,7 @@ builder.queryFields((t) => ({
     },
   }),
 
-  getInvitationInfo: t.field({
+  getInvitation: t.field({
     type: 'Invitation',
 
     args: {
@@ -135,7 +136,7 @@ builder.queryFields((t) => ({
     },
   }),
 
-  getResetTokenInfo: t.field({
+  getResetToken: t.field({
     type: 'ResetPasswordRequest',
 
     args: {


### PR DESCRIPTION
Following changes:-
- Fixed deleting the row from the reset_password_request table when resetting is successful.
- Changed the names from `getInvitationInfo` -> `getInvitation` and `getResetTokenInfo` -> `getResetToken`.
- GetInvitation also returns the email field.